### PR TITLE
wtf

### DIFF
--- a/test/test_casadi/test_casadi_wrapper.py
+++ b/test/test_casadi/test_casadi_wrapper.py
@@ -5,6 +5,7 @@ import scipy
 from hypothesis import given, assume
 
 import semantic_digital_twin.spatial_types.spatial_types as cas
+from semantic_digital_twin.datastructures.prefixed_name import PrefixedName
 from semantic_digital_twin.exceptions import (
     HasFreeSymbolsError,
     WrongDimensionsError,
@@ -142,6 +143,9 @@ class TestLogic3:
 
 
 class TestSymbol:
+    def test_muh(self):
+        a = PrefixedName("asd")
+
     def test_from_name(self):
         s = cas.Symbol(name="muh")
         assert isinstance(s, cas.Symbol)


### PR DESCRIPTION
```
============================= test session starts ==============================
collecting ... collected 1 item

test_casadi/test_casadi_wrapper.py::TestSymbol::test_muh 

========================= 1 failed, 1 warning in 2.00s =========================
FAILED          [100%]
test/test_casadi/test_casadi_wrapper.py:145 (TestSymbol.test_muh)
self = semantic_digital_twin.world_description.world_entity.WorldEntity.name

    @cached_property
    def resolved_type(self):
        try:
>           result = get_type_hints(self.clazz.clazz)[self.field.name]
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

../../../venvs/giskardpy/lib/python3.12/site-packages/krrood/class_diagrams/wrapped_field.py:88: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../../venvs/giskardpy/lib/python3.12/site-packages/typing_extensions.py:1499: in get_type_hints
    hint = typing.get_type_hints(
/usr/lib/python3.12/typing.py:2244: in get_type_hints
    value = _eval_type(value, base_globals, base_locals)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/lib/python3.12/typing.py:414: in _eval_type
    return t._evaluate(globalns, localns, recursive_guard)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = ForwardRef('Optional[World]')
globalns = {'__annotations__': {'_semantic_annotations': 'Set[SemanticAnnotation]', '_world': 'Optional[World]', 'name': 'Prefixe...e,eq=True,order=False,unsafe_hash=True,frozen=False,match_args=True,kw_only=False,slots=False,weakref_slot=False), ...}
localns = {'ABC': <class 'abc.ABC'>, 'Any': typing.Any, 'Body': <class 'semantic_digital_twin.world_description.world_entity.Bod...'BoundingBoxCollection': <class 'semantic_digital_twin.world_description.shape_collection.BoundingBoxCollection'>, ...}
recursive_guard = frozenset()

    def _evaluate(self, globalns, localns, recursive_guard):
        if self.__forward_arg__ in recursive_guard:
            return self
        if not self.__forward_evaluated__ or localns is not globalns:
            if globalns is None and localns is None:
                globalns = localns = {}
            elif globalns is None:
                globalns = localns
            elif localns is None:
                localns = globalns
            if self.__forward_module__ is not None:
                globalns = getattr(
                    sys.modules.get(self.__forward_module__, None), '__dict__', globalns
                )
            type_ = _type_check(
>               eval(self.__forward_code__, globalns, localns),
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                "Forward references must evaluate to types.",
                is_argument=self.__forward_is_argument__,
                allow_special_forms=self.__forward_is_class__,
            )
E           NameError: name 'World' is not defined

/usr/lib/python3.12/typing.py:924: NameError

During handling of the above exception, another exception occurred:

self = <test.test_casadi.test_casadi_wrapper.TestSymbol object at 0x77f0c682cd10>

    def test_muh(self):
>       a = PrefixedName("asd")
            ^^^^^^^^^^^^^^^^^^^

test_casadi/test_casadi_wrapper.py:147: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../../venvs/giskardpy/lib/python3.12/site-packages/krrood/entity_query_language/predicate.py:88: in __new__
    update_cache(instance)
../../../venvs/giskardpy/lib/python3.12/site-packages/krrood/entity_query_language/predicate.py:460: in update_cache
    SymbolGraph().add_node(WrappedInstance(instance))
    ^^^^^^^^^^^^^
../../../venvs/giskardpy/lib/python3.12/site-packages/krrood/singleton.py:22: in __call__
    cls._instances[cls] = super().__call__(*args, **kwargs)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
<string>:8: in __init__
    ???
../../../venvs/giskardpy/lib/python3.12/site-packages/krrood/entity_query_language/symbol_graph.py:187: in __post_init__
    self._class_diagram = ClassDiagram(list(recursive_subclasses(Symbol)))
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
<string>:6: in __init__
    ???
../../../venvs/giskardpy/lib/python3.12/site-packages/krrood/class_diagrams/class_diagram.py:178: in __post_init__
    self._create_all_relations()
../../../venvs/giskardpy/lib/python3.12/site-packages/krrood/class_diagrams/class_diagram.py:474: in _create_all_relations
    self._create_association_relations()
../../../venvs/giskardpy/lib/python3.12/site-packages/krrood/class_diagrams/class_diagram.py:490: in _create_association_relations
    target_type = wrapped_field.type_endpoint
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/lib/python3.12/functools.py:995: in __get__
    val = self.func(instance)
          ^^^^^^^^^^^^^^^^^^^
../../../venvs/giskardpy/lib/python3.12/site-packages/krrood/class_diagrams/wrapped_field.py:183: in type_endpoint
    if self.is_container or self.is_optional:
       ^^^^^^^^^^^^^^^^^
/usr/lib/python3.12/functools.py:995: in __get__
    val = self.func(instance)
          ^^^^^^^^^^^^^^^^^^^
../../../venvs/giskardpy/lib/python3.12/site-packages/krrood/class_diagrams/wrapped_field.py:121: in is_container
    return get_origin(self.resolved_type) in self.container_types
                      ^^^^^^^^^^^^^^^^^^
/usr/lib/python3.12/functools.py:995: in __get__
    val = self.func(instance)
          ^^^^^^^^^^^^^^^^^^^
../../../venvs/giskardpy/lib/python3.12/site-packages/krrood/class_diagrams/wrapped_field.py:101: in resolved_type
    found_clazz = manually_search_for_class_name(e.name)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

target_class_name = 'World'

    @lru_cache(maxsize=None)
    def manually_search_for_class_name(target_class_name: str) -> Type:
        """
        Searches for a class with the specified name in the current module's `globals()` dictionary
        and all loaded modules present in `sys.modules`. This function attempts to find and resolve
        the first class that matches the given name. If multiple classes are found with the same
        name, a warning is logged, and the first one is returned. If no matching class is found,
        an exception is raised.
    
        :param target_class_name: Name of the class to search for.
        :return: The resolved class with the matching name.
    
        :raises ValueError: Raised when no class with the specified name can be found.
        """
        found_classes = search_class_in_globals(target_class_name)
        found_classes += search_class_in_sys_modules(target_class_name)
    
        if len(found_classes) == 0:
>           raise TypeResolutionError(target_class_name)
E           krrood.class_diagrams.wrapped_field.TypeResolutionError: Could not resolve type for World

../../../venvs/giskardpy/lib/python3.12/site-packages/krrood/class_diagrams/wrapped_field.py:216: TypeResolutionError
```